### PR TITLE
Use new version of sender and fixes in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2019-07-02
+#### Changed
+ * Modified base devo-sender from version 2.x to >=3.0.1
+ * Faker cli for adapt to new devo-sdk config files
+ 
+#### Fixed
+ * Problems with Sender raw sender in CLI removing tag
+ * Problems with call key when can not exists
+
 ## [1.0.2] - 2019-04-24
 #### Security
  * Updated requirements for high problems of security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ changes have been made between each release (or version) of the project.
 
 ##### Why should I care?
 Because software tools are for people. If you don’t care, why are you 
-contributing? Right, Logtrust pay you for it, but surely, there must be a kernel
+contributing? Right, Devo maybe pay you for it, but surely, there must be a kernel
  (ha!) of care somewhere in that lovely little brain of yours.
 
 ##### What makes a good change log?

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![relese-next Build Status](https://travis-ci.com/DevoInc/python-utils.svg?branch=master)](https://travis-ci.com/DevoInc/python-utils) [![LICENSE](https://img.shields.io/dub/l/vibe-d.svg)](https://github.com/DevoInc/python-utils/blob/master/LICENSE)
 
-[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-utils/) [![version](https://img.shields.io/badge/version-2.0.0-blue.svg)](https://pypi.org/project/devo-utils/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7-blue.svg)](https://pypi.org/project/devo-utils/)
+[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-utils/) [![version](https://img.shields.io/badge/version-2.0.1-blue.svg)](https://pypi.org/project/devo-utils/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7-blue.svg)](https://pypi.org/project/devo-utils/)
 
 
 # Devo Python Utils

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![relese-next Build Status](https://travis-ci.com/DevoInc/python-utils.svg?branch=master)](https://travis-ci.com/DevoInc/python-utils) [![LICENSE](https://img.shields.io/dub/l/vibe-d.svg)](https://github.com/DevoInc/python-utils/blob/master/LICENSE)
 
-[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-utils/) [![version](https://img.shields.io/badge/version-1.0.2-blue.svg)](https://pypi.org/project/devo-utils/) [![python](https://img.shields.io/badge/python-3.3%20%7C%203.4%20%7C%203.5%20%7C%203.6%20%7C%203.7-blue.svg)](https://pypi.org/project/devo-utils/)
+[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-utils/) [![version](https://img.shields.io/badge/version-2.0.0-blue.svg)](https://pypi.org/project/devo-utils/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7-blue.svg)](https://pypi.org/project/devo-utils/)
 
 
 # Devo Python Utils

--- a/devoutils/__version__.py
+++ b/devoutils/__version__.py
@@ -1,7 +1,7 @@
 __description__ = 'Devo Python Library.'
 __url__ = 'http://www.devo.com'
-__version__ = "1.0.2"
+__version__ = "2.0.0"
 __author__ = 'Devo'
 __author_email__ = 'support@devo.com'
 __license__ = 'MIT'
-__copyright__ = 'Copyright 2018 Devo'
+__copyright__ = 'Copyright 2019 Devo'

--- a/devoutils/__version__.py
+++ b/devoutils/__version__.py
@@ -1,6 +1,6 @@
 __description__ = 'Devo Python Library.'
 __url__ = 'http://www.devo.com'
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __author__ = 'Devo'
 __author_email__ = 'support@devo.com'
 __license__ = 'MIT'

--- a/devoutils/faker/scripts/faker_cli.py
+++ b/devoutils/faker/scripts/faker_cli.py
@@ -31,7 +31,7 @@ def cli():
               help='Chain file for SSL.')
 @click.option('--address', help='address to send.')
 @click.option('--port', help='Port to send.')
-@click.option('--tag', help='Tag from Logtrust.')
+@click.option('--tag', help='Tag from Devo.')
 @click.option('--simulation', is_flag=True, help='Set as simulation.')
 @click.option('--template', '-t', type=click.File('r'), required=True,
               help='Template to send.')
@@ -40,8 +40,9 @@ def cli():
 @click.option('--raw_mode', '-raw', is_flag=True,
               help='Send raw mode.')
 @click.option('--prob', default=100, help='Probability (0-100).')
-@click.option('--freq', default="1-1", help='Frequency in seconds '
-                                            '("1.0-5.0": 1 sec. to 5secs.).')
+@click.option('--freq', default="1-1", help='Frequency in seconds. Example:'
+                                            '"1.0-5.0" = random time '
+                                            'between 1 sec. to 5secs.')
 @click.option('--batch_mode', is_flag=True,
               help='Enable blatch mode, a lot of events will be generated as '
                    'fast as possible and written to a file. The events will be '
@@ -88,21 +89,21 @@ def cli(**kwargs):
                 freq=cfg['freq'], date_format=cfg['date_format'],
                 dont_remove_microseconds=cfg['dont_remove_microseconds'])
         elif cfg['raw_mode']:
-            scfg = cfg['logtrust']
-            params.append('Host={0}:{1}'.format(scfg['address'], scfg['port']))
-            params.append('Tag={0}'.format(cfg['tag']))
-            thread = SyslogRawSender(engine, cfg['template'],
+            scfg = cfg['sender']
+            params.append('Host={0}:{1}'.format(scfg.get('address', None),
+                                                scfg.get("port", None)))
+            thread = SyslogRawSender(engine, cfg.get('template', None),
                                      interactive=cfg['interactive'],
-                                     prob=cfg['prob'], freq=cfg['freq'],
-                                     tag=cfg['tag'])
+                                     prob=cfg['prob'], freq=cfg['freq'])
         else:
-            scfg = cfg['logtrust']
-            params.append('Host={0}:{1}'.format(scfg['address'], scfg['port']))
-            params.append('Tag={0}'.format(cfg['tag']))
+            scfg = cfg['sender']
+            params.append('Host={0}:{1}'.format(scfg.get('address', None),
+                                                scfg.get("port", None)))
+            params.append('Tag={0}'.format(cfg.get('tag', "my.app.faker.test")))
             thread = SyslogSender(engine, cfg['template'],
                                   interactive=cfg['interactive'],
                                   prob=cfg['prob'], freq=cfg['freq'],
-                                  tag=cfg['tag'])
+                                  tag=cfg.get('tag', "my.app.faker.test"))
 
         params.append('Prob={0}'.format(cfg['prob']))
         params.append('Freq={0}'.format(cfg['freq']))
@@ -127,39 +128,37 @@ def cli(**kwargs):
 
 def configure(args):
     """For load configuration file/object"""
-    config = Configuration()
+
     if args.get('config'):
-        config.load_config(args.get('config'))
-    config.mix(dict(args))
+        config = Configuration(args.get('config'))
+        config.mix(dict(args))
+    else:
+        config = dict(args)
 
-    if 'freq' in config.cfg:
-        parts = config.cfg['freq'].split('-')
-        config.cfg['freq'] = (float(parts[0]), float(parts[1]))
+    if 'freq' in config.keys():
+        parts = config['freq'].split('-')
+        config['freq'] = (float(parts[0]), float(parts[1]))
 
-    config.cfg['template'] = config.cfg['template'].read()
+    config['template'] = config['template'].read()
 
     # Initialize LtSender with the config credentials but only
     # if we aren't in batch mode or simulation mode
     engine = None
-    if not (config.cfg['batch_mode'] or config.cfg['simulation']):
+    if not (config['batch_mode'] or config['simulation']):
         try:
-            if 'sender' in config.cfg:
-                engine = Sender.from_config(config.get()['sender'])
-            else:
-                config.cfg['sender'] = {
-                    'key' : config.cfg['key'],
-                    'chain' : config.cfg['chain'],
-                    'cert' : config.cfg['cert'],
-                    'address' : config.cfg['address'],
-                    'port' : config.cfg['port']
-                }
-                engine = Sender.from_config(config.cfg)
+            if "sender" not in config.keys():
+                config['sender'] = {'key': config.get('key', None),
+                                    'chain': config.get('chain', None),
+                                    'cert': config.get('cert', None),
+                                    'address': config.get('address', None),
+                                    'port': config.get('port', 443)}
+
+            engine = Sender(config=config.get('sender'))
         except Exception as error:
             print_error(error, show_help=False)
             print_error("Error when loading devo sender configuration",
                         show_help=True)
-
-    return engine, config.get()
+    return engine, config
 
 
 def print_error(error, show_help=False, stop=True):

--- a/devoutils/faker/senders/base_sender.py
+++ b/devoutils/faker/senders/base_sender.py
@@ -25,6 +25,7 @@ class BaseSender(threading.Thread):
         self.dont_remove_microseconds = kwargs.get('dont_remove_microseconds',
                                                    False)
         self.parser = TemplateParser()
+        self.date_generator = kwargs.get('date_generator', None)
 
     def process(self, date_generator=None, **kwargs):
         """Process template"""

--- a/devoutils/faker/senders/batch_sender.py
+++ b/devoutils/faker/senders/batch_sender.py
@@ -27,12 +27,12 @@ class BatchSender(BaseSender):
                    date_format="%Y-%m-%d %H:%M:%S.%f",
                    dont_remove_microseconds=True):
         """
-        Generates datetime objects between a start date and an end date with
+        Generates dateti
+        :param start_date:me objects between a start date and an end date with
         some given frequency,
         Some events can be piled up in the same millisecond, this happens
         sometimes with real data.
         :param frequency_ms:
-        :param start_date:
         :param end_date:
         :return:
         """

--- a/devoutils/faker/senders/syslog_raw_sender.py
+++ b/devoutils/faker/senders/syslog_raw_sender.py
@@ -9,7 +9,6 @@ class SyslogRawSender(BaseSender):
     """Generate a lot of events from/for Syslog"""
     def __init__(self, engine, template, **kwargs):
         BaseSender.__init__(self, engine, template, **kwargs)
-        self.tag = kwargs.get('tag', 'test.keep.free')
         self.kwargs = kwargs
 
     def run(self):

--- a/devoutils/faker/senders/syslog_sender.py
+++ b/devoutils/faker/senders/syslog_sender.py
@@ -14,10 +14,11 @@ class SyslogSender(BaseSender):
     def run(self):
         """Run function for cli or call function"""
         while True:
-            lines = self.process().split('\n')
+            lines = self.process(date_generator=self.date_generator).split('\n')
             for line in lines:
                 if self.probability():
-                    self.engine.send(tag=self.tag, msg=str(line))
+                    if not self.simulation:
+                        self.engine.send(tag=self.tag, msg=str(line))
                     now = datetime.utcnow().ctime()
                     print('{0} => {1}'.format(now, str(line)))
                 else:

--- a/docs/faker.md
+++ b/docs/faker.md
@@ -42,7 +42,7 @@ Options:
   -ch, --chain PATH            Chain file for SSL.
   --address TEXT               address to send.
   --port TEXT                  Port to send.
-  --tag TEXT                   Tag from Logtrust.
+  --tag TEXT                   Tag from Devo.
   --simulation                 Set as simulation.
   -t, --template FILENAME      Template to send.  [required]
   -i, --interactive            Interactive mode.

--- a/docs/sorter.md
+++ b/docs/sorter.md
@@ -262,5 +262,5 @@ it is not written to a file and an iterator is returned
 ## TODO
 * Include sort_stream function that receives an iterator and returns an iterator,
 the parameters would be the same as sort_file without source / destination file
-* Create writer that you send to Logtrust.
+* Create writer that you send to Devo.
 * More complex and complete tests.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Click==7.0
 requests==2.21.0
 pyyaml>=git+git://github.com/yaml/pyyaml@releases/tag/5.1b3
-devo-sdk>=2,<3
+devo-sdk==3.0.2
 Jinja2>=2.10.1
 psutil==5.6.1
 python-dateutil==2.8.0

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,14 @@ CLASSIFIERS = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.3",
-    "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-INSTALL_REQUIRES = ['devo-sdk', 'faker', 'jinja2>=2.10.1', 'psutil', 'click',
+INSTALL_REQUIRES = ['devo-sdk==3.0.2', 'faker', 'jinja2>=2.10.1', 'psutil', 'click',
                     'python-dateutil']
 CLI = ['devo-faker=devoutils.faker.scripts.faker_cli:cli']
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-INSTALL_REQUIRES = ['devo-sdk>=3.0.4,<4', 'faker', 'jinja2>=2.10.1', 'psutil',
+INSTALL_REQUIRES = ['devo-sdk>=3.0.3,<4', 'faker', 'jinja2>=2.10.1', 'psutil',
                     'click', 'python-dateutil']
 CLI = ['devo-faker=devoutils.faker.scripts.faker_cli:cli']
 

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ CLASSIFIERS = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-INSTALL_REQUIRES = ['devo-sdk==3.0.2', 'faker', 'jinja2>=2.10.1', 'psutil', 'click',
-                    'python-dateutil']
+INSTALL_REQUIRES = ['devo-sdk>=3.0.4,<4', 'faker', 'jinja2>=2.10.1', 'psutil',
+                    'click', 'python-dateutil']
 CLI = ['devo-faker=devoutils.faker.scripts.faker_cli:cli']
 
 


### PR DESCRIPTION
## [2.0.0] - 2019-07-02
#### Changed
 * Modified base devo-sender from version 2.x to >=3.0.1
 * Faker cli for adapt to new devo-sdk config files
 
#### Fixed
 * Problems with Sender raw sender in CLI removing tag
 * Problems with call key when can not exists